### PR TITLE
fixed compilation error on linux

### DIFF
--- a/Sources/buildpass/ReadCredential.swift
+++ b/Sources/buildpass/ReadCredential.swift
@@ -51,7 +51,9 @@ func readCredential(prompt: String) throws -> String {
             #if canImport(Darwin)
             memset_s(ptr.baseAddress, ptr.count, 0, ptr.count)
             #else
-            explicit_bzero(ptr.baseAddress, ptr.count)
+            if let base = ptr.baseAddress {
+                explicit_bzero(base, ptr.count)
+            }
             #endif
         }
     }


### PR DESCRIPTION
Trying to build the project on linux before returned this error:
```
/home/user/Projects/pass-builder/Sources/buildpass/ReadCredential.swift:54:32: error: value of optional type 'UnsafeMutableRawPointer?' must be unwrapped to a value of type 'UnsafeMutableRawPointer'
52 |             memset_s(ptr.baseAddress, ptr.count, 0, ptr.count)
53 |             #else
54 |             explicit_bzero(ptr.baseAddress, ptr.count)
   |                                |- error: value of optional type 'UnsafeMutableRawPointer?' must be unwrapped to a value of type 'UnsafeMutableRawPointer'
   |                                |- note: coalesce using '??' to provide a default when the optional value contains 'nil'
   |                                `- note: force-unwrap using '!' to abort execution if the optional value contains 'nil'
55 |             #endif
56 |         }
```
with this commit it does. I haven't tested it on a mac tho